### PR TITLE
Use window.getComputedStype(element) instead of element.style to be able...

### DIFF
--- a/scripts/send_images.js
+++ b/scripts/send_images.js
@@ -22,7 +22,7 @@
         }
       }
 
-      var backgroundImage = element.style['background-image'];
+      var backgroundImage = window.getComputedStyle(element)['background-image'];
       if (backgroundImage) {
         var parsedURL = imageDownloader.extractURLFromStyle(backgroundImage);
         if (imageDownloader.isImageURL(parsedURL)) {


### PR DESCRIPTION
... to retrieve more images.

element.style only reads styles that were specified inline on the image,
and not any styles from CSS stylesheets. The reason that some of these images can't be collected by
parsing document.styleSheets is that google chrome has a same-origin policy, and will not allow access
to stylesheets that are loaded from a different domain, such as CDNs.

Some chrome bugs tracking this issue:
https://code.google.com/p/chromium/issues/detail?id=143626
https://code.google.com/p/chromium/issues/detail?id=49001
https://code.google.com/p/chromium/issues/detail?id=45786
https://code.google.com/p/chromium/issues/detail?id=69626
