### PR TITLE
Added webm format inclusion

### DIFF
--- a/scripts/send_images.js
+++ b/scripts/send_images.js
@@ -3,7 +3,7 @@
   'use strict';
 
   var imageDownloader = {
-    imageRegex: /(?:([^:\/?#]+):)?(?:\/\/([^\/?#]*))?([^?#]*\.(?:jpe?g|gif|png))(?:\?([^#]*))?(?:#(.*))?/i,
+    imageRegex: /(?:([^:\/?#]+):)?(?:\/\/([^\/?#]*))?([^?#]*\.(?:jpe?g|gif|png|webm))(?:\?([^#]*))?(?:#(.*))?/i,
     mapElement: function (element) {
       if (element.tagName.toLowerCase() === 'img') {
         var src = element.src;


### PR DESCRIPTION
Added the webm format to the image listing.
Thumbnails do not display, but downloads work just fine

The change is trivial, but means I don't need to install a separate chrome extension for webm files.
